### PR TITLE
Transform JSF TCK

### DIFF
--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/application/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/application/build.xml
@@ -48,6 +48,7 @@
         	             includes="compOne.xhtml"
         	             prefix="resources/"/>
         	 <zipfileset dir="." includes="faces-config.xml" prefix="WEB-INF"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
         </ts.war>       

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationISE/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationISE/build.xml
@@ -39,6 +39,7 @@
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationWrapperISE/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationWrapperISE/build.xml
@@ -39,6 +39,7 @@
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationfactory/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationfactory/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/applicationwrapper/build.xml
@@ -43,6 +43,7 @@
 				${jsf.common}/util/JSFTestUtil.class" prefix="WEB-INF/classes" />
 			<zipfileset dir="." includes="faces-config.xml" prefix="WEB-INF" />
 			<zipfileset dir="${ts.home}/weblib" includes="*.jar" prefix="WEB-INF/lib" />
+			<zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/configurablenavigationhandler/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/configurablenavigationhandler/build.xml
@@ -34,6 +34,7 @@
         	 <zipfileset dir="." includes="faces-config.xml" prefix="WEB-INF"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/configurablenavigationhandlerwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/configurablenavigationhandlerwrapper/build.xml
@@ -34,6 +34,7 @@
         	 <zipfileset dir="." includes="faces-config.xml" prefix="WEB-INF"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/facesmessage/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/facesmessage/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/navigationcase/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/navigationcase/build.xml
@@ -42,6 +42,7 @@
         	 											 red.xhtml"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/navigationhandler/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/navigationhandler/build.xml
@@ -34,6 +34,7 @@
         	 <zipfileset dir="." includes="faces-config.xml" prefix="WEB-INF"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/protectedviewex/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/protectedviewex/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resource/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resource/build.xml
@@ -38,6 +38,7 @@
             <zipfileset dir="../common/resources"
                         includes="duke-boxer.gif"
                         prefix="resources/images"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcehandler/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcehandler/build.xml
@@ -37,6 +37,7 @@
             <zipfileset dir="../common/resources"
                         includes="background.css"
                         prefix="resources/style-sheets"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
 </project>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcehandlerEx/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcehandlerEx/build.xml
@@ -37,6 +37,7 @@
                         includes="neg_class_test.class"
                         prefix="resources"/>
             <fileset dir="${facelets.dir}" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
 </project>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcehandlerwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcehandlerwrapper/build.xml
@@ -38,6 +38,7 @@
             <zipfileset dir="../common/resources"
                         includes="background.css"
                         prefix="resources/style-sheets"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcewrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/resourcewrapper/build.xml
@@ -38,6 +38,7 @@
             <zipfileset dir="../common/resources"
                         includes="duke-boxer.gif"
                         prefix="resources/images"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/statemanager/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/statemanager/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
         <ts.war archivename="jsf_appl_statemgrs"
                 descriptor="jsf_appl_statemgrs_web.xml">
@@ -41,6 +42,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>   
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/statemanagerwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/statemanagerwrapper/build.xml
@@ -33,6 +33,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
         <ts.war archivename="jsf_appl_statemgrwraps"
                 descriptor="jsf_appl_statemgrwraps_web.xml">
@@ -42,6 +43,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>   
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewexpiredex/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewexpiredex/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandler/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandler/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>     
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandlerwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/application/viewhandlerwrapper/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/annotation/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/annotation/build.xml
@@ -36,6 +36,7 @@
                         prefix="resources/test"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
 </project>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/behavior/ajax/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/behavior/ajax/build.xml
@@ -37,6 +37,7 @@
 			<zipfileset dir="${ts.home}/weblib" 
 						includes="*.jar" 
 						prefix="WEB-INF/lib" />
+			<zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/behavior/clientbehaviorcontext/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/behavior/clientbehaviorcontext/build.xml
@@ -35,6 +35,7 @@
 			<zipfileset dir="${ts.home}/weblib" 
 						includes="*.jar" 
 						prefix="WEB-INF/lib" />
+			<zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlcommandbutton/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlcommandbutton/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlcommandlink/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlcommandlink/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmldatatable/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmldatatable/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlform/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlform/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlgraphicimage/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlgraphicimage/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputfile/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputfile/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputhidden/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputhidden/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputsecret/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputsecret/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputtext/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputtext/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputtextarea/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlinputtextarea/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlmessage/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlmessage/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlmessages/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlmessages/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutcometargetbutton/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutcometargetbutton/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutcometargetlink/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutcometargetlink/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputformat/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputformat/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputlabel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputlabel/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputlink/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputlink/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputtext/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmloutputtext/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlpanelgrid/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlpanelgrid/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlpanelgroup/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlpanelgroup/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectbooleancheckbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectbooleancheckbox/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanycheckbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanycheckbox/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanylistbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanylistbox/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanymenu/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectmanymenu/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectonelistbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectonelistbox/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectonemenu/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectonemenu/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectoneradio/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/html/htmlselectoneradio/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uicolumn/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uicolumn/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uicommand/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uicommand/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uidata/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uidata/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiform/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiform/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uigraphic/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uigraphic/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiinput/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiinput/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>     
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uimessage/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uimessage/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>      
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uimessages/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uimessages/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uinamingcontainer/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uinamingcontainer/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uioutcometarget/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uioutcometarget/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uioutput/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uioutput/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uipanel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uipanel/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiparameter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiparameter/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectboolean/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectboolean/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectitem/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectitem/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectitems/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectitems/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectmany/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectmany/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectone/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiselectone/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewaction/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewaction/build.xml
@@ -36,6 +36,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewparameter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewparameter/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>     
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewroot/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/component/uiviewroot/build.xml
@@ -38,6 +38,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/externalcontext/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/externalcontext/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/externalcontextfactory/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/externalcontextfactory/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/externalcontextwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/externalcontextwrapper/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontext/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontextfactory/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontextfactory/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontextwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/context/facescontextwrapper/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/bigdecimalconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/bigdecimalconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/bigintegerconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/bigintegerconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/booleanconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/booleanconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/byteconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/byteconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/characterconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/characterconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/datetimeconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/datetimeconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/doubleconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/doubleconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/enumconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/enumconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/floatconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/floatconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/integerconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/integerconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/localdateconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/localdateconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/localdatetimeconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/localdatetimeconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/localtimeconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/localtimeconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/longconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/longconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/numberconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/numberconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/offsetdatetimeconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/offsetdatetimeconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/offsettimeconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/offsettimeconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/shortconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/shortconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/zoneddatetimeconverter/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/convert/zoneddatetimeconverter/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/abortprocessingexception/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/abortprocessingexception/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/actionevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/actionevent/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/ajaxbehaviorevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/ajaxbehaviorevent/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/exceptionqueuedevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/exceptionqueuedevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/exceptionqueuedeventcontext/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/exceptionqueuedeventcontext/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/facesevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/facesevent/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/methodexpressionvaluechangelistener/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/methodexpressionvaluechangelistener/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/phaseevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/phaseevent/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postaddtoviewevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postaddtoviewevent/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postconstructapplicationevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postconstructapplicationevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postconstructcustomscopeevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postconstructcustomscopeevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postconstructviewmapevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postconstructviewmapevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postkeepflashvalueevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postkeepflashvalueevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postputflashvalueevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postputflashvalueevent/build.xml
@@ -29,6 +29,7 @@
                                   ${jsf.common}/util/JSFTestUtil.class,
                                   ${event.common.dir}/*.class" prefix="WEB-INF/classes" />
 			<zipfileset dir="${ts.home}/weblib" includes="*.jar" prefix="WEB-INF/lib" />
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postrenderviewevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postrenderviewevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postrestorestateevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postrestorestateevent/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postvalidateevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/postvalidateevent/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/preclearflashevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/preclearflashevent/build.xml
@@ -33,6 +33,7 @@
 			<zipfileset dir="${ts.home}/weblib" 
 						includes="*.jar" 
 						prefix="WEB-INF/lib" />
+			<zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/predestroyapplicationevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/predestroyapplicationevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/predestroyviewmapevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/predestroyviewmapevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/preremoveflashvalueevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/preremoveflashvalueevent/build.xml
@@ -29,6 +29,7 @@
                                   ${jsf.common}/util/JSFTestUtil.class,
                                   ${event.common.dir}/*.class" prefix="WEB-INF/classes" />
 			<zipfileset dir="${ts.home}/weblib" includes="*.jar" prefix="WEB-INF/lib" />
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/preremovefromviewevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/preremovefromviewevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/prerendercomponentevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/prerendercomponentevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/prerenderviewevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/prerenderviewevent/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/prevalidateevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/prevalidateevent/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/valuechangeevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/event/valuechangeevent/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/facesexception/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/facesexception/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/altfacesconfig/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/altfacesconfig/build.xml
@@ -48,6 +48,7 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="alt-faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/altfacesconfiglast/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/altfacesconfiglast/build.xml
@@ -49,6 +49,7 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="alt-faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/decorated/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/decorated/build.xml
@@ -52,6 +52,7 @@
             <zipfileset dir="${dist.dir}/${pkg.dir}" 
                         includes="jsftck-context.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/factoryfinder/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/factoryfinder/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/metainf/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/metainf/build.xml
@@ -48,6 +48,7 @@
             <zipfileset dir="${dist.dir}/${pkg.dir}" 
                         includes="jsftck-context.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/metainflast/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/metainflast/build.xml
@@ -49,6 +49,7 @@
             <zipfileset dir="${dist.dir}/${pkg.dir}" 
                         includes="jsftck-context.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/service/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/service/build.xml
@@ -48,6 +48,7 @@
             <zipfileset dir="${dist.dir}/${pkg.dir}" 
                         includes="jsftck-context.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/webinf/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinder/webinf/build.xml
@@ -48,6 +48,7 @@
             <zipfileset dir="${dist.dir}/${pkg.dir}" 
                         includes="jsftck-context.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/jsftck-context.jar"/>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinderrelease/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/factoryfinderrelease/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/flow/flowhandler/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/flow/flowhandler/build.xml
@@ -40,6 +40,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/lifecycle/lifecycle/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/lifecycle/lifecycle/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/lifecycle/lifecyclefactory/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/lifecycle/lifecyclefactory/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/lifecycle/lifecyclewrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/lifecycle/lifecyclewrapper/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/arraydatamodel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/arraydatamodel/build.xml
@@ -35,6 +35,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/collectiondatamodel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/collectiondatamodel/build.xml
@@ -35,6 +35,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/datamodelevent/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/datamodelevent/build.xml
@@ -34,6 +34,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/iterabledatamodel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/iterabledatamodel/build.xml
@@ -35,6 +35,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/listdatamodel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/listdatamodel/build.xml
@@ -35,6 +35,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/resultsetdatamodel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/resultsetdatamodel/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>      
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/scalardatamodel/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/scalardatamodel/build.xml
@@ -35,6 +35,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>    
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/selectitem/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/selectitem/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/selectitemgroup/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/model/selectitemgroup/build.xml
@@ -44,6 +44,7 @@
             <zipfileset dir="${ts.home}/weblib" 
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>        
     </target>
   

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/render/clientbehaviorrenderer/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/render/clientbehaviorrenderer/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib" 
             			includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
 </project>

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/render/renderkit/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/render/renderkit/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib" 
             			includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/render/renderkitfactory/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/render/renderkitfactory/build.xml
@@ -32,6 +32,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
 	

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/beanvalidator/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/beanvalidator/build.xml
@@ -32,6 +32,7 @@
                          prefix="WEB-INF/classes"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/doublerangevalidator/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/doublerangevalidator/build.xml
@@ -32,6 +32,7 @@
                          prefix="WEB-INF/classes"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/lengthvalidator/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/lengthvalidator/build.xml
@@ -33,6 +33,7 @@
                         prefix="WEB-INF/classes"/>
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
    

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/longrangevalidator/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/longrangevalidator/build.xml
@@ -33,6 +33,7 @@
                          prefix="WEB-INF/classes"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/methodexpressionvalidator/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/methodexpressionvalidator/build.xml
@@ -33,6 +33,7 @@
                          prefix="WEB-INF/classes"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/regexvalidator/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/validator/regexvalidator/build.xml
@@ -33,6 +33,7 @@
                          prefix="WEB-INF/classes"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/location/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/location/build.xml
@@ -32,6 +32,7 @@
                          prefix="WEB-INF/classes"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/statemanagementstrategy/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/statemanagementstrategy/build.xml
@@ -36,6 +36,7 @@
             	         prefix="resources/"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlang/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlang/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="../common" includes="myRoot.xhtml" /> 
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlangwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/api/jakarta_faces/view/viewdeclarationlangwrapper/build.xml
@@ -35,6 +35,7 @@
             	         prefix="resources/"/>
              <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                          prefix="WEB-INF/lib"/>
+             <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
          </ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/spec/ajax/common/AjaxTagValuesBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/ajax/common/AjaxTagValuesBean.java
@@ -24,9 +24,13 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 
 import jakarta.faces.event.ActionEvent;
+import java.io.Serializable;
+
 
 @jakarta.inject.Named("ajaxtag") @jakarta.enterprise.context.SessionScoped
-public class AjaxTagValuesBean {
+public class AjaxTagValuesBean implements Serializable {
+
+  private static final long serialVersionUID = -2564031884433676327L;
 
   private Integer count = 0;
 

--- a/src/com/sun/ts/tests/jsf/spec/ajax/jsresource/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/ajax/jsresource/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/jsresource"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/ajax/keyword/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/ajax/keyword/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/keyword"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/ajax/tagwrapper/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/ajax/tagwrapper/build.xml
@@ -37,6 +37,7 @@
                         prefix="${common.class.prefix}"/>
             <fileset dir="${facelets.dir}/tagwrapper"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/absolute_ordering/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/absolute_ordering/build.xml
@@ -54,6 +54,7 @@
             <zipfileset dir="."
                         includes="faces-configB.xml"
                         prefix="META-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
                         
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/AnswerNoBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/AnswerNoBean.java
@@ -20,8 +20,12 @@
 
 package com.sun.ts.tests.jsf.spec.appconfigresources.common.beans;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Question") @jakarta.enterprise.context.SessionScoped
-public class AnswerNoBean {
+public class AnswerNoBean implements Serializable {
+
+  private static final long serialVersionUID = -2564031884483456327L;
 
   private String answer;
 

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/ColorRedBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/ColorRedBean.java
@@ -19,8 +19,12 @@
  */
 package com.sun.ts.tests.jsf.spec.appconfigresources.common.beans;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Color") @jakarta.enterprise.context.SessionScoped
-public class ColorRedBean {
+public class ColorRedBean implements Serializable {
+
+  private static final long serialVersionUID = -2564031884483638087L;
 
   private String color;
 

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/OrderingBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/OrderingBean.java
@@ -22,6 +22,7 @@ package com.sun.ts.tests.jsf.spec.appconfigresources.common.beans;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.io.Serializable;
 
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.event.PhaseListener;
@@ -29,7 +30,9 @@ import jakarta.faces.lifecycle.Lifecycle;
 import jakarta.faces.lifecycle.LifecycleFactory;
 
 @jakarta.inject.Named("orderingBean") @jakarta.enterprise.context.SessionScoped
-public class OrderingBean {
+public class OrderingBean implements Serializable {
+
+  private static final long serialVersionUID = -2562021884483676327L;
 
   private String[] suffixes;
 

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/relative_ordering/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/relative_ordering/build.xml
@@ -61,6 +61,7 @@
 
             <fileset dir="${facelets.dir}/relative_ordering"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
         <delete file="${dist.dir}/${pkg.dir}/config.jar"/>
     </target>

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/startupbehavior/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/startupbehavior/build.xml
@@ -58,6 +58,7 @@
 
             <fileset dir="${facelets.dir}/startupbehavior"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
         <delete file="${dist.dir}/${pkg.dir}/jsftck-resource.jar"/>
     </target>

--- a/src/com/sun/ts/tests/jsf/spec/composite/actionsource/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/actionsource/build.xml
@@ -44,6 +44,7 @@
                         prefix="WEB-INF"/>
                         
             <fileset dir="${facelet.dir}/actionsource" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/composite/attribute/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/attribute/build.xml
@@ -46,6 +46,7 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/build.xml
@@ -45,6 +45,7 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/composite/facet/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/facet/build.xml
@@ -40,6 +40,7 @@
                         prefix="resources/tckcomp"/>
 
             <fileset dir="${facelet.dir}/facet" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/composite/insertchildren/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/insertchildren/build.xml
@@ -41,6 +41,7 @@
 
             <fileset dir="${facelet.dir}/insertchildren"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/composite/packaging/classpath/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/packaging/classpath/build.xml
@@ -47,6 +47,7 @@
                         prefix="WEB-INF/lib"/>
                         
             <fileset dir="${facelet.dir}/packaging/classpath" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
 
         <delete file="${dist.dir}/${pkg.dir}/tckComponent.jar" />

--- a/src/com/sun/ts/tests/jsf/spec/composite/packaging/webapproot/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/packaging/webapproot/build.xml
@@ -48,6 +48,7 @@
                         prefix="resources/versioned/2_0"/>
 
             <fileset dir="${facelet.dir}/packaging/webapproot" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/composite/valueholder/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/composite/valueholder/build.xml
@@ -41,6 +41,7 @@
 
             <fileset dir="${facelet.dir}/valueholder"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/coretags/selectitems/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/coretags/selectitems/build.xml
@@ -40,6 +40,8 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="faces-config.xml"
                         prefix="WEB-INF"/>
+
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/coretags/viewaction/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/coretags/viewaction/build.xml
@@ -40,6 +40,7 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/el/elresolvers/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/el/elresolvers/build.xml
@@ -38,6 +38,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>      
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/common/CommonBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/common/CommonBean.java
@@ -26,6 +26,8 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
+@jakarta.inject.Named("commonBean")
+@jakarta.enterprise.context.RequestScoped
 public class CommonBean {
 
   private String escapeString = "><&'\"";

--- a/src/com/sun/ts/tests/jsf/spec/jstl/common/faces-config.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/common/faces-config.xml
@@ -22,12 +22,5 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
     version="3.0">
 
-    <managed-bean>
-        <managed-bean-name>commonBean</managed-bean-name>
-        <managed-bean-class>
-            com.sun.ts.tests.jsf.spec.jstl.common.CommonBean
-        </managed-bean-class>
-        <managed-bean-scope>request</managed-bean-scope>
-    </managed-bean>
     
 </faces-config>

--- a/src/com/sun/ts/tests/jsf/spec/jstl/cwo/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/cwo/build.xml
@@ -34,6 +34,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/cwo" 
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fncontains/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fncontains/build.xml
@@ -34,6 +34,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fncontains"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fncontainsignore/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fncontainsignore/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fncontainsignore"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnendswith/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnendswith/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnendswith"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnescapexml/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnescapexml/build.xml
@@ -40,6 +40,7 @@
             <zipfileset dir="${jstl.common.class}"
                         includes="faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnindexof/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnindexof/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnindexof"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnjoin/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnjoin/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnjoin"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnlength/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnlength/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnlength"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnreplace/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnreplace/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnreplace"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnsplit/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnsplit/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnsplit"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnstartswith/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnstartswith/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnstartswith"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnsubstring/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnsubstring/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnsubstring"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnsubstringafter/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnsubstringafter/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnsubstringafter"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fnsubstringbefore/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fnsubstringbefore/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fnsubstringbefore"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fntolowercase/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fntolowercase/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fntolowercase"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fntouppercase/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fntouppercase/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fntouppercase"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/fntrim/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/fntrim/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/fntrim"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/foreachtag/BandBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/foreachtag/BandBean.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.Vector;
 
+@jakarta.inject.Named("Band")
+@jakarta.enterprise.context.RequestScoped
 public class BandBean {
 
   private String[] firstNames = { "Geddy", "Alex", "Neil" };

--- a/src/com/sun/ts/tests/jsf/spec/jstl/foreachtag/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/foreachtag/build.xml
@@ -41,6 +41,7 @@
             <zipfileset dir="${src.dir}/${pkg.dir}"
                         includes="faces-config.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/jstl/foreachtag/faces-config.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/foreachtag/faces-config.xml
@@ -22,12 +22,5 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
     version="3.0">
 
-    <managed-bean>
-        <managed-bean-name>Band</managed-bean-name>
-        <managed-bean-class>
-            com.sun.ts.tests.jsf.spec.jstl.foreachtag.BandBean
-        </managed-bean-class>
-        <managed-bean-scope>request</managed-bean-scope>
-    </managed-bean>
 
 </faces-config>

--- a/src/com/sun/ts/tests/jsf/spec/jstl/iftag/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/jstl/iftag/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/iftag" 
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/navigation/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/navigation/build.xml
@@ -33,6 +33,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/body/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/body/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/body"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/booleancheckbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/booleancheckbox/build.xml
@@ -40,6 +40,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/booleancheckbox" 
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/commandbutton/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/commandbutton/build.xml
@@ -43,6 +43,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/commandbutton" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/commandlink/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/commandlink/build.xml
@@ -41,6 +41,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/commandlink" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/common/AttributeBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/AttributeBean.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 @jakarta.inject.Named("Attribute") @jakarta.enterprise.context.SessionScoped
 public class AttributeBean {
+  
+  @jakarta.enterprise.context.Dependent
   public Map<String, Object> attMap = new HashMap<String, Object>();
 
   {

--- a/src/com/sun/ts/tests/jsf/spec/render/datatable/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/datatable/build.xml
@@ -44,6 +44,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/datatable" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>  
 </project>

--- a/src/com/sun/ts/tests/jsf/spec/render/form/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/form/build.xml
@@ -40,6 +40,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/form" includes="*"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/graphic/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/graphic/build.xml
@@ -44,6 +44,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/graphic" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>    
 </project>

--- a/src/com/sun/ts/tests/jsf/spec/render/grid/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/grid/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/grid" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/head/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/head/build.xml
@@ -37,6 +37,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/head"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/hidden/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/hidden/build.xml
@@ -40,6 +40,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/hidden" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/inputtext/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/inputtext/build.xml
@@ -39,6 +39,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/inputtext" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/manycheckbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/manycheckbox/build.xml
@@ -38,6 +38,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/manycheckbox" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/manylistbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/manylistbox/build.xml
@@ -38,6 +38,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/manylistbox" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/manymenu/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/manymenu/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/manymenu" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/message/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/message/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/message" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/messages/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/messages/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/messages" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/onelistbox/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/onelistbox/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/onelistbox" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/onemenu/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/onemenu/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/onemenu" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/oneradio/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/oneradio/build.xml
@@ -38,6 +38,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/oneradio" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/outputformat/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputformat/build.xml
@@ -36,6 +36,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/outputformat" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/outputlabel/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputlabel/build.xml
@@ -36,6 +36,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/outputlabel" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/outputlink/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputlink/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/outputlink" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/outputscript/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputscript/build.xml
@@ -40,6 +40,7 @@
                         prefix="resources/jsLibrary"/>
             <fileset dir="${facelets.dir}/outputscript"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/outputstyle/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputstyle/build.xml
@@ -40,6 +40,7 @@
                         prefix="resources/cssLibrary"/>
             <fileset dir="${facelets.dir}/outputstyle"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/outputtext/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputtext/build.xml
@@ -36,6 +36,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/outputtext" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/secret/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/secret/build.xml
@@ -36,6 +36,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/secret" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/render/textarea/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/render/textarea/build.xml
@@ -36,6 +36,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/textarea" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/resource/packaging/classpath/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/resource/packaging/classpath/build.xml
@@ -79,6 +79,7 @@
             <zipfileset dir="${common.locales}"
                         includes="*.properties"
                         prefix="WEB-INF/classes/${tests.pkg.dir}/jsf/spec/resource/common"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
         
         <delete file="${dist.dir}/${pkg.dir}/jsftck-resource.jar"/>

--- a/src/com/sun/ts/tests/jsf/spec/resource/packaging/webapproot/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/resource/packaging/webapproot/build.xml
@@ -117,6 +117,7 @@
             <zipfileset dir="${class.dir}" 
                         includes="${tests.pkg.dir}/jsf/spec/resource/common/util/ResourceChecker.class"
                         prefix="WEB-INF/classes"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/resource/relocatable/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/resource/relocatable/build.xml
@@ -37,6 +37,7 @@
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/relocatable" includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/templating/common/NameBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/templating/common/NameBean.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 
 import jakarta.faces.component.UIOutput;
 
+@jakarta.inject.Named("Character")
+@jakarta.enterprise.context.RequestScoped
 public class NameBean implements Serializable {
 
   private UIOutput name;

--- a/src/com/sun/ts/tests/jsf/spec/templating/component/faces-config.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/component/faces-config.xml
@@ -22,12 +22,5 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
     version="3.0">
 
-    <managed-bean>
-        <managed-bean-name>Character</managed-bean-name>
-        <managed-bean-class>
-            com.sun.ts.tests.jsf.spec.templating.common.NameBean
-        </managed-bean-class>
-        <managed-bean-scope>request</managed-bean-scope>
-    </managed-bean>
 
 </faces-config>

--- a/src/com/sun/ts/tests/jsf/spec/templating/fragment/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/fragment/build.xml
@@ -34,6 +34,7 @@
 			<fileset dir="${facelets.dir}/fragment" includes="*.xhtml" />
 
 			<zipfileset dir="${src.dir}/${pkg.dir}" includes="faces-config.xml" prefix="WEB-INF" />
+			<zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
 		</ts.war>
 	</target>
 

--- a/src/com/sun/ts/tests/jsf/spec/templating/fragment/faces-config.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/fragment/faces-config.xml
@@ -22,12 +22,4 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
     version="3.0">
 
-    <managed-bean>
-        <managed-bean-name>Character</managed-bean-name>
-        <managed-bean-class>
-            com.sun.ts.tests.jsf.spec.templating.common.NameBean
-        </managed-bean-class>
-        <managed-bean-scope>request</managed-bean-scope>
-    </managed-bean>
-
 </faces-config>

--- a/src/com/sun/ts/tests/jsf/spec/templating/insert/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/insert/build.xml
@@ -34,6 +34,7 @@
                         prefix="WEB-INF/lib"/>
             <fileset dir="${facelets.dir}/insert"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/templating/remove/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/remove/build.xml
@@ -36,6 +36,7 @@
 
             <fileset dir="${facelets.dir}/remove"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/templating/repeat/ColorBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/templating/repeat/ColorBean.java
@@ -23,6 +23,8 @@ package com.sun.ts.tests.jsf.spec.templating.repeat;
 import java.util.ArrayList;
 import java.util.List;
 
+@jakarta.inject.Named("Color")
+@jakarta.enterprise.context.RequestScoped
 public class ColorBean {
 
   private List<String> colors = new ArrayList<String>();

--- a/src/com/sun/ts/tests/jsf/spec/templating/repeat/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/repeat/build.xml
@@ -36,6 +36,7 @@
                         
             <fileset dir="${facelets.dir}/repeat"
                      includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/templating/repeat/faces-config.xml
+++ b/src/com/sun/ts/tests/jsf/spec/templating/repeat/faces-config.xml
@@ -22,12 +22,5 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
     version="3.0">
 
-    <managed-bean>
-        <managed-bean-name>Color</managed-bean-name>
-        <managed-bean-class>
-            com.sun.ts.tests.jsf.spec.templating.repeat.ColorBean
-        </managed-bean-class>
-        <managed-bean-scope>request</managed-bean-scope>
-    </managed-bean>
 
 </faces-config>

--- a/src/com/sun/ts/tests/jsf/spec/view/protectedview/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/view/protectedview/build.xml
@@ -38,6 +38,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>      
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/view/viewhandler/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/view/viewhandler/build.xml
@@ -38,6 +38,7 @@
             <zipfileset dir="${ts.home}/weblib"
                         includes="*.jar"
                         prefix="WEB-INF/lib"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>      
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/webapp/factoryfinder/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/factoryfinder/build.xml
@@ -35,6 +35,7 @@
                         prefix="WEB-INF/lib"/>
             <zipfileset dir="WEB-INF" includes="**/*.xml"
                         prefix="WEB-INF"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>       
     </target>
     

--- a/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/build.xml
+++ b/src/com/sun/ts/tests/jsf/spec/webapp/tldsig/build.xml
@@ -36,6 +36,7 @@
             <zipfileset dir="${ts.home}/weblib" includes="*.jar"
                         prefix="WEB-INF/lib"/>
             <zipfileset dir="." includes="*.xhtml"/>
+            <zipfileset dir="${src.dir}/${jsf.common}" includes="beans.xml" prefix="WEB-INF"/>
         </ts.war>    
     </target>
 </project>


### PR DESCRIPTION

**Describe the change**

- Add empty beans.xml to all wars as the deployment was failing before tests were executed. 
- Few more Managedbeans to @jakarta.inject.Named
- Some of the server log errors with `Managed bean declaring a passivating scope must be passivation capable`  were resolved by implementing Serializable interface for those bean classes. 
- There are also issues with `Normal scoped managed bean implementation class has a public field` for which it was attempted to resolve by adding `@jakarta.enterprise.context.Dependent` to the field for `src/com/sun/ts/tests/jsf/spec/render/common/AttributeBean.java` but did not help, this file was accidentally committed.

@BalusC 