### PR TITLE
fix some more deployment errors

### DIFF
--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/AnswerYesBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/AnswerYesBean.java
@@ -19,8 +19,12 @@
  */
 package com.sun.ts.tests.jsf.spec.appconfigresources.common.beans;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Answer") @jakarta.enterprise.context.SessionScoped
-public class AnswerYesBean {
+public class AnswerYesBean implements Serializable {
+
+  private static final long serialVersionUID = -2564071088038088087L;
 
   private String answer;
 

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/ColorBlueBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/ColorBlueBean.java
@@ -19,8 +19,12 @@
  */
 package com.sun.ts.tests.jsf.spec.appconfigresources.common.beans;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Ball") @jakarta.enterprise.context.SessionScoped
-public class ColorBlueBean {
+public class ColorBlueBean implements Serializable {
+
+  private static final long serialVersionUID = -2564071088038087108L; 
 
   private String color;
 

--- a/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/StatBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/appconfigresources/common/beans/StatBean.java
@@ -20,8 +20,13 @@
 
 package com.sun.ts.tests.jsf.spec.appconfigresources.common.beans;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Status") @jakarta.enterprise.context.SessionScoped
-public class StatBean {
+public class StatBean implements Serializable {
+
+  private static final long serialVersionUID = -2538081884483638087L;
+
   private String testString;
 
   /** Creates a new instance of StatBean */

--- a/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/FirstNameBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/FirstNameBean.java
@@ -23,9 +23,12 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AbortProcessingException;
 import jakarta.faces.event.ValueChangeEvent;
 import jakarta.faces.event.ValueChangeListener;
+import java.io.Serializable;
 
 @jakarta.inject.Named("firstname") @jakarta.enterprise.context.SessionScoped
-public class FirstNameBean implements ValueChangeListener {
+public class FirstNameBean implements ValueChangeListener, Serializable {
+
+  private static final long serialVersionUID = -2564031838038087108L; 
 
   public ValueChangeListener getValueChangeListener() {
     ValueChangeListener fname = new FirstNameBean();

--- a/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/LastNameBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/composite/editablevalueholder/LastNameBean.java
@@ -24,8 +24,12 @@ import jakarta.faces.event.AbortProcessingException;
 import jakarta.faces.event.ValueChangeEvent;
 import jakarta.faces.event.ValueChangeListener;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("lastname") @jakarta.enterprise.context.SessionScoped
-public class LastNameBean implements ValueChangeListener {
+public class LastNameBean implements ValueChangeListener, Serializable {
+
+  private static final long serialVersionUID = -2564031838083638087L;
 
   public ValueChangeListener getValueChangeListener() {
     ValueChangeListener lname = new LastNameBean();

--- a/src/com/sun/ts/tests/jsf/spec/render/commandbutton/CommandButtonUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/commandbutton/CommandButtonUIBean.java
@@ -20,10 +20,13 @@
 
 package com.sun.ts.tests.jsf.spec.render.commandbutton;
 
+import java.io.Serializable;
 import jakarta.faces.component.html.HtmlCommandButton;
 
 @jakarta.inject.Named("status") @jakarta.enterprise.context.SessionScoped
-public class CommandButtonUIBean {
+public class CommandButtonUIBean implements Serializable {
+
+  private static final long serialVersionUID = -2574855687654356327L;
 
   private HtmlCommandButton onoff;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/common/AttributeBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/AttributeBean.java
@@ -22,12 +22,14 @@ package com.sun.ts.tests.jsf.spec.render.common;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.io.Serializable;
 
 @jakarta.inject.Named("Attribute") @jakarta.enterprise.context.SessionScoped
-public class AttributeBean {
+public class AttributeBean implements Serializable {
+
+  private static final long serialVersionUID = -2564380871083456327L;
   
-  @jakarta.enterprise.context.Dependent
-  public Map<String, Object> attMap = new HashMap<String, Object>();
+  private Map<String, Object> attMap = new HashMap<String, Object>();
 
   {
     attMap.put("manyattone", "manyOne");

--- a/src/com/sun/ts/tests/jsf/spec/render/common/EscapeBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/EscapeBean.java
@@ -16,8 +16,13 @@
 
 package com.sun.ts.tests.jsf.spec.render.common;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Escape") @jakarta.enterprise.context.SessionScoped
-public class EscapeBean {
+public class EscapeBean implements Serializable {
+
+  private static final long serialVersionUID = -3544855687654980327L;
+  
   private String foo;
 
   private String bar;

--- a/src/com/sun/ts/tests/jsf/spec/render/common/MessageBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/MessageBean.java
@@ -20,11 +20,15 @@
 
 package com.sun.ts.tests.jsf.spec.render.common;
 
+import java.io.Serializable;
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.context.FacesContext;
 
 @jakarta.inject.Named("Message") @jakarta.enterprise.context.SessionScoped
-public class MessageBean {
+public class MessageBean implements Serializable {
+
+  private static final long serialVersionUID = -2156780871083890367L;
+
   private static String INFO_SUMMARY = "INFO: Summary Message";
 
   private static String INFO_DETAIL = "INFO: Detailed Message";

--- a/src/com/sun/ts/tests/jsf/spec/render/common/OutputUIComponentBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/OutputUIComponentBean.java
@@ -19,12 +19,15 @@
  */
 package com.sun.ts.tests.jsf.spec.render.common;
 
+import java.io.Serializable;
 import jakarta.faces.component.html.HtmlOutputLabel;
 import jakarta.faces.component.html.HtmlOutputLink;
 import jakarta.faces.component.html.HtmlOutputText;
 
 @jakarta.inject.Named("Out") @jakarta.enterprise.context.SessionScoped
-public class OutputUIComponentBean {
+public class OutputUIComponentBean implements Serializable {
+
+  private static final long serialVersionUID = -2564325687654356327L;
 
   private HtmlOutputLabel label;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/common/SelectMany01Bean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/SelectMany01Bean.java
@@ -16,6 +16,7 @@
 
 package com.sun.ts.tests.jsf.spec.render.common;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -38,7 +39,9 @@ import jakarta.faces.model.SelectItem;
  * $Id:
  */
 @jakarta.inject.Named("select01") @jakarta.enterprise.context.SessionScoped
-public class SelectMany01Bean {
+public class SelectMany01Bean implements Serializable {
+
+  private static final long serialVersionUID = -8823380871067856327L;
 
   private final Collection<SelectItem> possibleValues;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/common/SelectUIComponentBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/SelectUIComponentBean.java
@@ -20,13 +20,16 @@
 
 package com.sun.ts.tests.jsf.spec.render.common;
 
+import java.io.Serializable;
 import jakarta.faces.application.Application;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UISelectItem;
 import jakarta.faces.context.FacesContext;
 
 @jakarta.inject.Named("Answer") @jakarta.enterprise.context.SessionScoped
-public class SelectUIComponentBean {
+public class SelectUIComponentBean implements Serializable {
+
+  private static final long serialVersionUID = -2564323472383456327L;
 
   private UIComponent yesNo;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/common/SimpleActionListener.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/SimpleActionListener.java
@@ -21,6 +21,7 @@
 package com.sun.ts.tests.jsf.spec.render.common;
 
 import java.util.Map;
+import java.io.Serializable;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.ExternalContext;
@@ -31,7 +32,9 @@ import jakarta.faces.event.ActionListener;
 import jakarta.servlet.http.HttpServletResponse;
 
 @jakarta.inject.Named("ActionListener") @jakarta.enterprise.context.SessionScoped
-public class SimpleActionListener implements ActionListener {
+public class SimpleActionListener implements ActionListener, Serializable {
+
+  private static final long serialVersionUID = -2123380871083456327L;
 
   /**
    * <p>

--- a/src/com/sun/ts/tests/jsf/spec/render/common/StatBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/common/StatBean.java
@@ -20,8 +20,13 @@
 
 package com.sun.ts.tests.jsf.spec.render.common;
 
+import java.io.Serializable;
+
 @jakarta.inject.Named("Status") @jakarta.enterprise.context.SessionScoped
-public class StatBean {
+public class StatBean implements Serializable {
+
+  private static final long serialVersionUID = -2808031838038088087L;
+  
   private String formOneOutput = "";
 
   private String formTwoOutput = "";

--- a/src/com/sun/ts/tests/jsf/spec/render/datatable/DataTableUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/datatable/DataTableUIBean.java
@@ -19,6 +19,7 @@
  */
 package com.sun.ts.tests.jsf.spec.render.datatable;
 
+import java.io.Serializable;
 import jakarta.faces.application.Application;
 import jakarta.faces.component.html.HtmlColumn;
 import jakarta.faces.component.html.HtmlDataTable;
@@ -26,7 +27,9 @@ import jakarta.faces.component.html.HtmlOutputText;
 import jakarta.faces.context.FacesContext;
 
 @jakarta.inject.Named("library") @jakarta.enterprise.context.SessionScoped
-public class DataTableUIBean {
+public class DataTableUIBean implements Serializable {
+
+  private static final long serialVersionUID = -2574855687654980327L;
 
   private HtmlDataTable books;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/form/FormUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/form/FormUIBean.java
@@ -19,13 +19,16 @@
  */
 package com.sun.ts.tests.jsf.spec.render.form;
 
+import java.io.Serializable;
 import jakarta.faces.application.Application;
 import jakarta.faces.component.html.HtmlForm;
 import jakarta.faces.component.html.HtmlInputText;
 import jakarta.faces.context.FacesContext;
 
 @jakarta.inject.Named("greeting") @jakarta.enterprise.context.SessionScoped
-public class FormUIBean {
+public class FormUIBean implements Serializable {
+
+  private static final long serialVersionUID = -2123380871451256327L;
 
   private HtmlForm myForm;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/graphic/GraphicUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/graphic/GraphicUIBean.java
@@ -20,10 +20,13 @@
 
 package com.sun.ts.tests.jsf.spec.render.graphic;
 
+import java.io.Serializable;
 import jakarta.faces.component.html.HtmlGraphicImage;
 
 @jakarta.inject.Named("pictures") @jakarta.enterprise.context.SessionScoped
-public class GraphicUIBean {
+public class GraphicUIBean implements Serializable {
+
+  private static final long serialVersionUID = -4324855687654980327L;
 
   private HtmlGraphicImage img1;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/grid/GridUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/grid/GridUIBean.java
@@ -25,9 +25,12 @@ import jakarta.faces.component.html.HtmlColumn;
 import jakarta.faces.component.html.HtmlOutputText;
 import jakarta.faces.component.html.HtmlPanelGrid;
 import jakarta.faces.context.FacesContext;
+import java.io.Serializable;
 
 @jakarta.inject.Named("location") @jakarta.enterprise.context.SessionScoped
-public class GridUIBean {
+public class GridUIBean implements Serializable {
+
+  private static final long serialVersionUID = -2564031838083638087L;
 
   private HtmlPanelGrid gps;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/hidden/HiddenUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/hidden/HiddenUIBean.java
@@ -20,9 +20,12 @@
 package com.sun.ts.tests.jsf.spec.render.hidden;
 
 import jakarta.faces.component.html.HtmlInputHidden;
+import java.io.Serializable;
 
 @jakarta.inject.Named("scene") @jakarta.enterprise.context.SessionScoped
-public class HiddenUIBean {
+public class HiddenUIBean implements Serializable {
+
+  private static final long serialVersionUID = -2564031838038088087L;
 
   private HtmlInputHidden seeMe;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/inputtext/InputTextUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/inputtext/InputTextUIBean.java
@@ -19,10 +19,13 @@
  */
 package com.sun.ts.tests.jsf.spec.render.inputtext;
 
+import java.io.Serializable;
 import jakarta.faces.component.html.HtmlInputText;
 
 @jakarta.inject.Named("Hello") @jakarta.enterprise.context.SessionScoped
-public class InputTextUIBean {
+public class InputTextUIBean implements Serializable {
+
+  private static final long serialVersionUID = -2564325672383456327L;
 
   private HtmlInputText greeting;
 

--- a/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterBean.java
@@ -24,9 +24,9 @@ import java.io.Serializable;
 @jakarta.inject.Named("info") @jakarta.enterprise.context.SessionScoped
 public class FormatterBean implements Serializable {
 
-  public String technology = "JSF";
+  private String technology = "JSF";
 
-  public String component = "f:param";
+  private String component = "f:param";
 
   /** Creates a new instance of MessageBean */
   public FormatterBean() {


### PR DESCRIPTION
**Describe the change**
The pending server log errors with `Managed bean declaring a passivating scope must be passivation capable` were resolved by implementing Serializable interface for those bean classes.

Pending deployement errors are of type :
`Normal scoped managed bean implementation class has a public field` for which it was attempted to resolve by adding @jakarta.enterprise.context.Dependent to the field for src/com/sun/ts/tests/jsf/spec/render/common/AttributeBean.java.
    Any other known solution ?

@BalusC
