### PR TITLE
Last fix for deployment error

### DIFF
--- a/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterUIBean.java
+++ b/src/com/sun/ts/tests/jsf/spec/render/outputformat/FormatterUIBean.java
@@ -19,10 +19,13 @@
  */
 package com.sun.ts.tests.jsf.spec.render.outputformat;
 
+import java.io.Serializable;
 import jakarta.faces.component.html.HtmlOutputFormat;
 
 @jakarta.inject.Named("score") @jakarta.enterprise.context.SessionScoped
-public class FormatterUIBean {
+public class FormatterUIBean implements Serializable {
+
+  private static final long serialVersionUID = -9564143088038088087L;
 
   private HtmlOutputFormat fscore;
 


### PR DESCRIPTION
**Describe the change**
Fixes the last one deployment issue , in continuation with https://github.com/BalusC/jakartaee-tck/pull/3.

There is also a requirement to double the heap size in glassfish7/glassfish/domains/domain1/config/domain.xml when running against glassfish7 as I was getting OOM error when run in local. Will handle the jsf test run script (docker/jsftck.sh) with this change later. 

@BalusC 

Can you please raise a PR in jakartaee-tck master with the changes in this branch. 